### PR TITLE
Keep class CoordinateContainer visible 

### DIFF
--- a/Mapbox.Sdk.Geojson/Transforms/Metadata.xml
+++ b/Mapbox.Sdk.Geojson/Transforms/Metadata.xml
@@ -14,5 +14,5 @@
     <attr path="/api/package[@name='com.mapbox.geojson.gson']/class[@name='PointSerializer']/method[@name='serialize' and count(parameter)=3 and parameter[1][@type='com.mapbox.geojson.Point'] and parameter[2][@type='java.lang.reflect.Type'] and parameter[3][@type='com.google.gson.JsonSerializationContext']]/parameter[1]" name="managedType">Java.Lang.Object</attr>
     <remove-node path="/api/package[@name='com.mapbox.geojson.gson']/class[@name='GeometryTypeAdapter']/method[@name='write' and count(parameter)=2 and parameter[1][@type='com.google.gson.stream.JsonWriter'] and parameter[2][@type='com.mapbox.geojson.Geometry']]" />
     <remove-node path="/api/package[@name='com.mapbox.geojson.gson']/class[@name='GeometryTypeAdapter']/method[@name='read' and count(parameter)=1 and parameter[1][@type='com.google.gson.stream.JsonReader']]" />
-    <remove-node path="/api/package[@name='com.mapbox.geojson']/interface[@name='CoordinateContainer']" />
+    <remove-node path="/api/package[@name='com.mapbox.geojson']/interface[@name='CoordinateContainer']/method[@name='coordinates' and count(parameter)=0]" />
 </metadata>


### PR DESCRIPTION
Hi Brad,

Can you please review this small changes and push a new Nuget package? Only a minor update in Metadata file which keeps using the CoordinateContainer class. This update would enable us to generate GeoJsonSource manually with a list of LatLng objects as mapbox sample code. Below is sample Xamarin.Android code which work after this change:

``` csharp
public static GeoJsonSource CreateLineStringSource(string id, IList<LatLng> coordinates)
{
    var points = coordinates.Select(c => Point.FromLngLat(c.Longitude, c.Latitude)).ToArray();
    LineString lineString = LineString.FromLngLats(points);
    FeatureCollection featureCollection = FeatureCollection.FromFeatures(new[]{Feature.FromGeometry(lineString) });
    return new GeoJsonSource(id, featureCollection);
}
```